### PR TITLE
Always show asset in Editor.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,5 +2,6 @@
   "name": "com.yasirkula.ingamedebugconsole",
   "displayName": "In-game Debug Console",
   "version": "1.3.0",
-  "description": "This asset helps you see debug messages (logs, warnings, errors, exceptions) runtime in a build (also assertions in editor) and execute commands using its built-in console. It also supports logging logcat messages to the console on Android platform."
+  "description": "This asset helps you see debug messages (logs, warnings, errors, exceptions) runtime in a build (also assertions in editor) and execute commands using its built-in console. It also supports logging logcat messages to the console on Android platform.",
+  "hideInEditor": false
 }


### PR DESCRIPTION
In Unity Editor 2020, packages are hidden by default and it is not possible to add the prefabs. This PR will show the package in the project again.