### PR TITLE
Fix console text input recording keypresses when minimised with hotkey

### DIFF
--- a/Plugins/IngameDebugConsole/Scripts/DebugLogManager.cs
+++ b/Plugins/IngameDebugConsole/Scripts/DebugLogManager.cs
@@ -581,6 +581,10 @@ namespace IngameDebugConsole
 			logWindowCanvasGroup.blocksRaycasts = true;
 			logWindowCanvasGroup.alpha = 1f;
 
+			//Reset the text in the input field and reenable input capture
+			commandInputField.text = "";
+			commandInputField.enabled = true;
+
 			popupManager.Hide();
 
 			// Update the recycled list view 
@@ -605,6 +609,9 @@ namespace IngameDebugConsole
 			logWindowCanvasGroup.interactable = false;
 			logWindowCanvasGroup.blocksRaycasts = false;
 			logWindowCanvasGroup.alpha = 0f;
+
+			//Disable input field to prevent capturing of input when hidden
+			commandInputField.enabled = false;
 
 			popupManager.Show();
 


### PR DESCRIPTION
When using the hotkey to hide the console the command input field continues capturing input (including ENTER which will submit the text for action). When opening it again it will have the junk captured and the show/hide hotkey character as appliable.

This fix disables the command input field when hidden and clears the text in the input field and reenables it when toggled open (clearing text could also be a toggleable option).