### PR TITLE
Return back to command after checking out history.

### DIFF
--- a/Plugins/IngameDebugConsole/Scripts/DebugLogManager.cs
+++ b/Plugins/IngameDebugConsole/Scripts/DebugLogManager.cs
@@ -576,7 +576,8 @@ namespace IngameDebugConsole
 					if( commandHistoryIndex == -1 )
 					{
 						commandHistoryIndex = commandHistory.Count - 1;
-						commandHistory.Add(commandInputField.text);
+						if(commandInputField.text != "")
+							commandHistory.Add(commandInputField.text);
 					}
 					else if( ++commandHistoryIndex >= commandHistory.Count )
 					{

--- a/Plugins/IngameDebugConsole/Scripts/DebugLogManager.cs
+++ b/Plugins/IngameDebugConsole/Scripts/DebugLogManager.cs
@@ -555,9 +555,15 @@ namespace IngameDebugConsole
 				if( Input.GetKeyDown( KeyCode.UpArrow ) )
 				{
 					if( commandHistoryIndex == -1 )
+					{
 						commandHistoryIndex = commandHistory.Count - 1;
+						if(commandInputField.text != "")
+							commandHistory.Add(commandInputField.text);
+					}
 					else if( --commandHistoryIndex < 0 )
+					{
 						commandHistoryIndex = 0;
+					}
 
 					if( commandHistoryIndex >= 0 && commandHistoryIndex < commandHistory.Count )
 					{
@@ -568,9 +574,14 @@ namespace IngameDebugConsole
 				else if( Input.GetKeyDown( KeyCode.DownArrow ) )
 				{
 					if( commandHistoryIndex == -1 )
+					{
 						commandHistoryIndex = commandHistory.Count - 1;
+						commandHistory.Add(commandInputField.text);
+					}
 					else if( ++commandHistoryIndex >= commandHistory.Count )
+					{
 						commandHistoryIndex = commandHistory.Count - 1;
+					}
 
 					if( commandHistoryIndex >= 0 && commandHistoryIndex < commandHistory.Count )
 						commandInputField.text = commandHistory[commandHistoryIndex];


### PR DESCRIPTION
I often when typing commands reference variables from my command history, and it has been bothering me a long time that the command I was typing before checking out history wasn't saved. I am so used to this functionality in PowerShell that it missing really started bugging me.

"commandHistoryIndex" is reset to -1 every time a valid command is typed, so I assumed checking this value would be the best way of determining whether we are looking at the history or not.