### PR TITLE
Add obj.toggletype and obj.typealiases commands

### DIFF
--- a/Plugins/IngameDebugConsole/Scripts/Commands/ObjectCommands.cs
+++ b/Plugins/IngameDebugConsole/Scripts/Commands/ObjectCommands.cs
@@ -97,7 +97,7 @@ namespace IngameDebugConsole.Commands
 		{
 			string loweredKeyword = keyword.ToLower();
 			List<GameObject> allSceneObjects = new List<GameObject>();
-			for (int i = 0; i < SceneManager.sceneCount; ++i)
+			for ( int i = 0; i < SceneManager.sceneCount; ++i )
 			{
 				GameObject[] rootGameObjects = SceneManager.GetSceneAt( i )
 					.GetRootGameObjects();
@@ -121,7 +121,7 @@ namespace IngameDebugConsole.Commands
 		{
 			string loweredKeyword = keyword.ToLower();
 			List<GameObject> allSceneObjects = new List<GameObject>();
-			for (int i = 0; i < SceneManager.sceneCount; ++i)
+			for ( int i = 0; i < SceneManager.sceneCount; ++i )
 			{
 				GameObject[] rootGameObjects = SceneManager.GetSceneAt( i )
 					.GetRootGameObjects();

--- a/Plugins/IngameDebugConsole/Scripts/Commands/ObjectCommands.cs
+++ b/Plugins/IngameDebugConsole/Scripts/Commands/ObjectCommands.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using UnityEngine;
+using System.Linq;
+using Type = System.Type;
+
+namespace IngameDebugConsole.Commands
+{
+	public class ObjectCommands
+	{
+		public static Dictionary<string, string> TypeAliases
+			= new Dictionary<string, string>()
+			{
+				{ "rin.rh", "RuntimeInspectorNamespace.RuntimeHierarchy" },
+				{ "rin.ri", "RuntimeInspectorNamespace.RuntimeInspector" }
+			};
+
+		[ConsoleMethod( "obj.toggletype",
+			"Finds the first GameObject containing a component with a type"
+			+ "name containing the argument, or type alias matching the argument, "
+			+ "toggles its activeSelf property" ),
+			UnityEngine.Scripting.Preserve]
+		public static void ToggleType( string keyword )
+		{
+			string loweredKeyword = keyword.ToLower();
+			string typeName;
+			Type searchType;
+			bool exactTypeName = false;
+			if ( TypeAliases.ContainsKey( loweredKeyword ) )
+			{ typeName = TypeAliases[loweredKeyword]; exactTypeName = true; }
+			else typeName = loweredKeyword;
+
+			IEnumerable<Type> allFoundTypes = System.AppDomain.CurrentDomain
+				.GetAssemblies()
+				.Reverse()
+				.SelectMany( a => a.GetTypes() );
+			if ( exactTypeName )
+				searchType = allFoundTypes.FirstOrDefault( t => t.FullName == typeName );
+			else searchType = allFoundTypes.FirstOrDefault( t => t.Name.ToLower().Contains( typeName ) );
+
+			if ( searchType == null ) return;
+			Object foundObj = Object.FindObjectOfType( searchType, true );
+			if ( foundObj == null) return;
+			Component foundComp = foundObj as Component;
+			if ( foundObj == null ) return;
+			foundComp.gameObject.SetActive( !foundComp.gameObject.activeSelf );
+		}
+
+		[ConsoleMethod( "obj.typealiases",
+			"Returns a list of alias-to-type-name mappings in "
+			+ "IngameDebugConsole.Commands.ObjectCommands.TypeAliases and used by "
+			+ "the obj.toggletype command" ),
+			UnityEngine.Scripting.Preserve]
+		public static string ListTypeAliases()
+		{
+			return string.Join( "\n",
+				TypeAliases.Select( p => "[" + p.Key + "] = " + p.Value ) );
+		}
+	}
+}

--- a/Plugins/IngameDebugConsole/Scripts/Commands/ObjectCommands.cs
+++ b/Plugins/IngameDebugConsole/Scripts/Commands/ObjectCommands.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using Type = System.Type;
 using System.Reflection;
 using System;
+using UnityEngine.SceneManagement;
 
 namespace IngameDebugConsole.Commands
 {
@@ -45,6 +46,36 @@ namespace IngameDebugConsole.Commands
 			foundComp.gameObject.SetActive( !foundComp.gameObject.activeSelf );
 		}
 
+		[ConsoleMethod( "obj.toggletype",
+			"Finds the first GameObject containing a component with a type"
+			+ "name containing the argument, or type alias matching the argument, "
+			+ "toggles its activeSelf property" ),
+			UnityEngine.Scripting.Preserve]
+		public static void ToggleType( bool state, string keyword )
+		{
+			string loweredKeyword = keyword.ToLower();
+			string typeName;
+			Type searchType;
+			bool exactTypeName = false;
+			if ( TypeAliases.ContainsKey( loweredKeyword ) )
+			{ typeName = TypeAliases[loweredKeyword]; exactTypeName = true; }
+			else typeName = loweredKeyword;
+
+			List<Type> allFoundTypes = new List<Type>();
+			foreach ( Assembly a in AppDomain.CurrentDomain.GetAssemblies() )
+				foreach ( Type t in a.GetTypes() ) allFoundTypes.Add( t );
+			if ( exactTypeName )
+				searchType = allFoundTypes.Find( t => t.FullName == typeName );
+			else searchType = allFoundTypes.Find( t => t.Name.ToLower().Contains( typeName ) );
+
+			if ( searchType == null ) return;
+			UnityEngine.Object foundObj = UnityEngine.Object.FindObjectOfType( searchType, true );
+			if ( foundObj == null ) return;
+			Component foundComp = foundObj as Component;
+			if ( foundObj == null ) return;
+			foundComp.gameObject.SetActive( state );
+		}
+
 		[ConsoleMethod( "obj.typealiases",
 			"Returns a list of alias-to-type-name mappings in "
 			+ "IngameDebugConsole.Commands.ObjectCommands.TypeAliases and used by "
@@ -56,6 +87,54 @@ namespace IngameDebugConsole.Commands
 			foreach ( KeyValuePair<string, string> p in TypeAliases )
 				lines.Add( "[" + p.Key + "] = " + p.Value );
 			return string.Join( "\n", lines.ToArray() );
+		}
+
+		[ConsoleMethod( "obj.togglename",
+			"Finds the first GameObject with a name containing the argument, "
+			+ "toggles its activeSelf property" ),
+			UnityEngine.Scripting.Preserve]
+		public static void ToggleName( string keyword )
+		{
+			string loweredKeyword = keyword.ToLower();
+			List<GameObject> allSceneObjects = new List<GameObject>();
+			for (int i = 0; i < SceneManager.sceneCount; ++i)
+			{
+				GameObject[] rootGameObjects = SceneManager.GetSceneAt( i )
+					.GetRootGameObjects();
+				allSceneObjects.AddRange( rootGameObjects );
+				foreach ( GameObject go in rootGameObjects )
+					foreach ( Transform t in go.GetComponentsInChildren<Transform>( true ) )
+						allSceneObjects.Add( t.gameObject );
+			}
+			foreach ( GameObject go in allSceneObjects )
+			{
+				if ( go.name.ToLower().Contains( loweredKeyword ) )
+				{	go.SetActive( !go.activeSelf ); return; }
+			}
+		}
+
+		[ConsoleMethod( "obj.togglename",
+			"Finds the first GameObject with a name containing the argument, "
+			+ "toggles its activeSelf property" ),
+			UnityEngine.Scripting.Preserve]
+		public static void ToggleName( bool state, string keyword )
+		{
+			string loweredKeyword = keyword.ToLower();
+			List<GameObject> allSceneObjects = new List<GameObject>();
+			for (int i = 0; i < SceneManager.sceneCount; ++i)
+			{
+				GameObject[] rootGameObjects = SceneManager.GetSceneAt( i )
+					.GetRootGameObjects();
+				allSceneObjects.AddRange( rootGameObjects );
+				foreach ( GameObject go in rootGameObjects )
+					foreach ( Transform t in go.GetComponentsInChildren<Transform>( true ) )
+						allSceneObjects.Add( t.gameObject );
+			}
+			foreach ( GameObject go in allSceneObjects )
+			{
+				if ( go.name.ToLower().Contains( loweredKeyword ) )
+				{	go.SetActive( state ); return; }
+			}
 		}
 	}
 }

--- a/Plugins/IngameDebugConsole/Scripts/Commands/ObjectCommands.cs
+++ b/Plugins/IngameDebugConsole/Scripts/Commands/ObjectCommands.cs
@@ -39,7 +39,7 @@ namespace IngameDebugConsole.Commands
 
 			if ( searchType == null ) return;
 			UnityEngine.Object foundObj = UnityEngine.Object.FindObjectOfType( searchType, true );
-			if ( foundObj == null) return;
+			if ( foundObj == null ) return;
 			Component foundComp = foundObj as Component;
 			if ( foundObj == null ) return;
 			foundComp.gameObject.SetActive( !foundComp.gameObject.activeSelf );

--- a/Plugins/IngameDebugConsole/Scripts/Commands/ObjectCommands.cs.meta
+++ b/Plugins/IngameDebugConsole/Scripts/Commands/ObjectCommands.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 50d4ba69b466c6e4abc2171889c32982
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The main addition of this PR is the `obj.toggletype` command.

`obj.toggletype` takes a keyword, finds a `Component` with a type name that contains that keyword (case-insensitive) from all runtime assemblies, finds the first `GameObject` that contains that `Component`, then toggles its active state.

Alternatively, the keyword argument can be a shortened alias to a full type name. The alias-to-type-name mappings are open for registration by programmers through `IngameDebugConsole.Commands.ObjectCommands.TypeAliases`. Type names registered here are expected to be `FullName`.

The 2 aliases pre-registered for this command are `rin.rh` & `rin.ri`, which map to the [Runtime Hierachy & Inspector](https://github.com/yasirkula/UnityRuntimeInspector) respectively. This PR began as a command that turns on & off Runtime Hierachy & Inspector, but expanded into a general-purpose command. It still ships with built-in Runtime Hierachy & Inspector integration so that you can turn on & off those objects with `obj.toggletype rin.rh`.

`obj.typealiases` is a companion command to print out the current content of the `IngameDebugConsole.Commands.ObjectCommands.TypeAliases` Dictionary.