### PR TITLE
Add method to return all commands. Add delegate to list for any commands executed

### DIFF
--- a/Plugins/IngameDebugConsole/Scripts/DebugLogConsole.cs
+++ b/Plugins/IngameDebugConsole/Scripts/DebugLogConsole.cs
@@ -54,6 +54,13 @@ namespace IngameDebugConsole
 	{
 		public delegate bool ParseFunction( string input, out object output );
 
+		public delegate void CommandExecutedDelegate( string command, object[] parameters );
+
+		/// <summary>
+		/// Event invoked when a command is executed
+		/// </summary>
+		public static event CommandExecutedDelegate OnCommandExecuted;
+
 		// All the commands
 		private static readonly List<ConsoleMethodInfo> methods = new List<ConsoleMethodInfo>();
 		private static readonly List<ConsoleMethodInfo> matchingMethods = new List<ConsoleMethodInfo>( 4 );
@@ -754,6 +761,8 @@ namespace IngameDebugConsole
 					else
 						Debug.Log( "Returned: " + result.ToString() );
 				}
+				
+				OnCommandExecuted?.Invoke( methodToExecute.command, parameters );
 			}
 		}
 

--- a/Plugins/IngameDebugConsole/Scripts/DebugLogConsole.cs
+++ b/Plugins/IngameDebugConsole/Scripts/DebugLogConsole.cs
@@ -212,6 +212,15 @@ namespace IngameDebugConsole
 			}
 		}
 
+		/// <summary>
+		/// Returns list of all commands
+		/// </summary>
+		/// <returns></returns>
+		public static List<ConsoleMethodInfo> GetAllCommands()
+		{
+			return methods;
+		}
+		
 		// Logs the list of available commands
 		public static void LogAllCommands()
 		{

--- a/Plugins/IngameDebugConsole/Scripts/DebugLogConsole.cs
+++ b/Plugins/IngameDebugConsole/Scripts/DebugLogConsole.cs
@@ -55,10 +55,6 @@ namespace IngameDebugConsole
 		public delegate bool ParseFunction( string input, out object output );
 
 		public delegate void CommandExecutedDelegate( string command, object[] parameters );
-
-		/// <summary>
-		/// Event invoked when a command is executed
-		/// </summary>
 		public static event CommandExecutedDelegate OnCommandExecuted;
 
 		// All the commands
@@ -219,15 +215,11 @@ namespace IngameDebugConsole
 			}
 		}
 
-		/// <summary>
-		/// Returns list of all commands
-		/// </summary>
-		/// <returns></returns>
 		public static List<ConsoleMethodInfo> GetAllCommands()
 		{
 			return methods;
 		}
-		
+
 		// Logs the list of available commands
 		public static void LogAllCommands()
 		{
@@ -761,8 +753,9 @@ namespace IngameDebugConsole
 					else
 						Debug.Log( "Returned: " + result.ToString() );
 				}
-				
-				OnCommandExecuted?.Invoke( methodToExecute.command, parameters );
+
+				if( OnCommandExecuted != null )
+					OnCommandExecuted( methodToExecute.command, parameters );
 			}
 		}
 


### PR DESCRIPTION
I needed a way to remove all commands that I've added as my users were using `scene.load` etc and wasn't working with my custom scene management. I couldn't find a way to loop over all the commands that didn't require reflection. 

The delegate I added was mainly to log to console any command that had run so when I got bug reports in Sentry I could see what they were trying to do. 

Below is an example use case for these features.

```csharp
    private void Start()
    {
        DebugLogConsole.OnCommandExecuted += OnCommandExecuted;
        RemoveStockCommands();
    }

    private static void OnCommandExecuted(string command, object[] parameters)
    {
        if (parameters?.Length > 0)
            Debug.Log($"Command executed '{command}' with parameters: {string.Join(", ", parameters)}");
        else
            Debug.Log($"Command executed: {command}");
    }

    private static void RemoveStockCommands()
    {
        // need to copy as can cause enumeration exceptions
        var comamnds = new List<ConsoleMethodInfo>(DebugLogConsole.GetAllCommands());
        foreach (var m in comamnds)
        {
            if (!m.command.StartsWith('/'))
                DebugLogConsole.RemoveCommand(m.command);
        }
    }
```