### PR TITLE
Saving command history between sessions

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -27,8 +27,8 @@ There are 5 ways to install this plugin:
 - import [IngameDebugConsole.unitypackage](https://github.com/yasirkula/UnityIngameDebugConsole/releases) via *Assets-Import Package*
 - clone/[download](https://github.com/yasirkula/UnityIngameDebugConsole/archive/master.zip) this repository and move the *Plugins* folder to your Unity project's *Assets* folder
 - import it from [Asset Store](https://assetstore.unity.com/packages/tools/gui/in-game-debug-console-68068)
-- *(via Package Manager)* add the following line to *Packages/manifest.json*:
-  - `"com.yasirkula.ingamedebugconsole": "https://github.com/yasirkula/UnityIngameDebugConsole.git",`
+- (FOR THIS FORK, USE THIS WAY)*(via Package Manager)* add the following line to *Packages/manifest.json*:*(via Package Manager)* add the following line to *Packages/manifest.json*:
+  - `"com.mikolaj505.yasirkula.ingamedebugconsole": "https://github.com/Mikolaj505/UnityIngameDebugConsole_SaveCommands.git",`
 - *(via [OpenUPM](https://openupm.com))* after installing [openupm-cli](https://github.com/openupm/openupm-cli), run the following command:
   - `openupm add com.yasirkula.ingamedebugconsole`
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -2,7 +2,7 @@
 
 <img height="235" src="Images/1.png" alt="screenshot" /> <img height="235" src="Images/2.png" alt="screenshot2" />
 
-**Available on Asset Store:** https://assetstore.unity.com/packages/tools/gui/in-game-debug-console-68068
+**Available on Asset Store:** https://assetstore.unity.com/packages/tools/gui/in-game-debug-console-68068 
 
 **Forum Thread:** http://forum.unity3d.com/threads/in-game-debug-console-with-ugui-free.411323/
 

--- a/Plugins/IngameDebugConsole/Editor/DebugLogManagerEditor.cs
+++ b/Plugins/IngameDebugConsole/Editor/DebugLogManagerEditor.cs
@@ -32,6 +32,9 @@ namespace IngameDebugConsole
 		private SerializedProperty queuedLogLimit;
 		private SerializedProperty clearCommandAfterExecution;
 		private SerializedProperty commandHistorySize;
+		private SerializedProperty saveCommandHistoryBetweenSessions;
+		private SerializedProperty commandHistorySeparator;
+		private SerializedProperty commandHistorySaveKey;
 		private SerializedProperty showCommandSuggestions;
 		private SerializedProperty receiveLogcatLogsInAndroid;
 		private SerializedProperty logcatArguments;
@@ -80,6 +83,9 @@ namespace IngameDebugConsole
 			queuedLogLimit = serializedObject.FindProperty( "queuedLogLimit" );
 			clearCommandAfterExecution = serializedObject.FindProperty( "clearCommandAfterExecution" );
 			commandHistorySize = serializedObject.FindProperty( "commandHistorySize" );
+            saveCommandHistoryBetweenSessions = serializedObject.FindProperty("saveCommandHistoryBetweenSessions");
+            commandHistorySeparator = serializedObject.FindProperty("commandHistorySeparator");
+            commandHistorySaveKey = serializedObject.FindProperty("commandHistorySaveKey");
 			showCommandSuggestions = serializedObject.FindProperty( "showCommandSuggestions" );
 			receiveLogcatLogsInAndroid = serializedObject.FindProperty( "receiveLogcatLogsInAndroid" );
 			logcatArguments = serializedObject.FindProperty( "logcatArguments" );
@@ -170,6 +176,9 @@ namespace IngameDebugConsole
 
 			EditorGUILayout.PropertyField( clearCommandAfterExecution );
 			EditorGUILayout.PropertyField( commandHistorySize );
+			EditorGUILayout.PropertyField( saveCommandHistoryBetweenSessions );
+			EditorGUILayout.PropertyField( commandHistorySeparator );
+			EditorGUILayout.PropertyField( commandHistorySaveKey );
 			EditorGUILayout.PropertyField( showCommandSuggestions );
 			EditorGUILayout.PropertyField( autoFocusOnCommandInputField );
 

--- a/Plugins/IngameDebugConsole/Scripts/CommandHistorySaveManager.cs
+++ b/Plugins/IngameDebugConsole/Scripts/CommandHistorySaveManager.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+namespace IngameDebugConsole
+{
+    public class CommandHistorySaveManager
+	{
+		private CircularBuffer<string> commandHistory;
+		private int commandHistorySize;
+		private string commandHistorySaveSeparator = ";";
+		private string commandHistorySaveKey;
+
+
+        private List<string> tempBufferValues;
+
+
+        public CommandHistorySaveManager(CircularBuffer<string> commandHistory, int commandHistorySize, string commandHistorySaveSeparator, string commandHistorySaveKey)
+        {
+            this.commandHistory = commandHistory;
+            this.commandHistorySize = commandHistorySize;
+            this.commandHistorySaveSeparator = commandHistorySaveSeparator;
+			this.commandHistorySaveKey = commandHistorySaveKey;
+
+			tempBufferValues = new();
+        }
+
+        public void SaveCommands(CircularBuffer<string> currentCommandHistory) 
+		{
+			tempBufferValues.Clear();
+			for (int i = 0; i < currentCommandHistory.Count; i++)
+			{
+				tempBufferValues.Add(currentCommandHistory[i]);
+			}
+
+			string newCommandHistorySave = string.Join(commandHistorySaveSeparator, tempBufferValues.ToArray());
+			PlayerPrefs.SetString(commandHistorySaveKey, newCommandHistorySave);
+			PlayerPrefs.Save();
+		}
+
+        public void LoadAllCommandsToCommandHistory()
+		{
+            string commandHistorySave = PlayerPrefs.GetString(commandHistorySaveKey);
+
+            string[] loadedCommands = commandHistorySave.Split(commandHistorySaveSeparator);
+
+			LoadCommandsIntoBuffer(loadedCommands, commandHistory, commandHistorySize);
+        }
+
+		private void LoadCommandsIntoBuffer(string[] commands, CircularBuffer<string> buffer, int capacity)
+		{
+			int loadCount = Math.Min(commands.Length, capacity);
+
+            for (int i = 0; i < loadCount; i++)
+            {
+                buffer.Add(commands[i]);
+            }
+        }
+    }
+}

--- a/Plugins/IngameDebugConsole/Scripts/CommandHistorySaveManager.cs.meta
+++ b/Plugins/IngameDebugConsole/Scripts/CommandHistorySaveManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f3f3e819f97d4234e9c23563895e2eaf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "com.Mikolaj505.yasirkula.ingamedebugconsole",
+  "name": "com.mikolaj505.yasirkula.ingamedebugconsole",
   "displayName": "In-game Debug Console",
   "version": "1.6.7",
   "documentationUrl": "https://github.com/Mikolaj505/UnityIngameDebugConsole_SaveCommands",
   "licensesUrl": "https://github.com/Mikolaj505/UnityIngameDebugConsole_SaveCommands",
-  "description": "(This is a ford of the original plugin, adding functionality of saving commands history between sessions) This asset helps you see debug messages (logs, warnings, errors, exceptions) runtime in a build (also assertions in editor) and execute commands using its built-in console. It also supports logging logcat messages to the console on Android platform.",
+  "description": "(This is a fork of the original plugin, adding functionality of saving commands history between sessions) This asset helps you see debug messages (logs, warnings, errors, exceptions) runtime in a build (also assertions in editor) and execute commands using its built-in console. It also supports logging logcat messages to the console on Android platform.",
   "hideInEditor": false
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
-  "name": "com.yasirkula.ingamedebugconsole",
+  "name": "com.Mikolaj505.yasirkula.ingamedebugconsole",
   "displayName": "In-game Debug Console",
   "version": "1.6.7",
-  "documentationUrl": "https://github.com/yasirkula/UnityIngameDebugConsole",
-  "changelogUrl": "https://github.com/yasirkula/UnityIngameDebugConsole/releases",
-  "licensesUrl": "https://github.com/yasirkula/UnityIngameDebugConsole/blob/master/LICENSE.txt",
-  "description": "This asset helps you see debug messages (logs, warnings, errors, exceptions) runtime in a build (also assertions in editor) and execute commands using its built-in console. It also supports logging logcat messages to the console on Android platform.",
+  "documentationUrl": "https://github.com/Mikolaj505/UnityIngameDebugConsole_SaveCommands",
+  "licensesUrl": "https://github.com/Mikolaj505/UnityIngameDebugConsole_SaveCommands",
+  "description": "(This is a ford of the original plugin, adding functionality of saving commands history between sessions) This asset helps you see debug messages (logs, warnings, errors, exceptions) runtime in a build (also assertions in editor) and execute commands using its built-in console. It also supports logging logcat messages to the console on Android platform.",
   "hideInEditor": false
 }


### PR DESCRIPTION
Dear maintainer, this a PR from my fork of your repo. I've been using ingame debug console for a while in many different projects over years, but always found the commands gettings lost between sessions annoying. I believe it is a standard feature for a console, and will be a great addition to your excellent project, making it even better. 

It's a simple save using PlayerPrefs and it's fully configurable from DebugLogManager inspector.

Since your work is boosting Unity games for free, I wanted to share what I believe is a nice improvement with the rest of the community.

Grateful for the plugin as it is,
Mikolaj505