### PR TITLE
Define UNITY_ANDROID_JNI when the module is enabled

### DIFF
--- a/Plugins/IngameDebugConsole/Android/DebugLogLogcatListener.cs
+++ b/Plugins/IngameDebugConsole/Android/DebugLogLogcatListener.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR || UNITY_ANDROID
+#if (UNITY_EDITOR || UNITY_ANDROID) && UNITY_ANDROID_JNI
 using System.Collections.Generic;
 using UnityEngine;
 

--- a/Plugins/IngameDebugConsole/IngameDebugConsole.Runtime.asmdef
+++ b/Plugins/IngameDebugConsole/IngameDebugConsole.Runtime.asmdef
@@ -1,6 +1,22 @@
-﻿{
+{
     "name": "IngameDebugConsole.Runtime",
+    "rootNamespace": "",
     "references": [
         "Unity.InputSystem"
-    ]
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.modules.androidjni",
+            "expression": "",
+            "define": "UNITY_ANDROID_JNI"
+        }
+    ],
+    "noEngineReferences": false
 }

--- a/Plugins/IngameDebugConsole/Scripts/DebugLogItem.cs
+++ b/Plugins/IngameDebugConsole/Scripts/DebugLogItem.cs
@@ -14,7 +14,7 @@ namespace IngameDebugConsole
 	{
 		#region Platform Specific Elements
 #if !UNITY_2018_1_OR_NEWER
-#if !UNITY_EDITOR && UNITY_ANDROID
+#if !UNITY_EDITOR && UNITY_ANDROID && UNITY_ANDROID_JNI
 		private static AndroidJavaClass m_ajc = null;
 		private static AndroidJavaClass AJC
 		{

--- a/Plugins/IngameDebugConsole/Scripts/DebugLogManager.cs
+++ b/Plugins/IngameDebugConsole/Scripts/DebugLogManager.cs
@@ -601,11 +601,17 @@ namespace IngameDebugConsole
 
 			if( receiveLogcatLogsInAndroid )
 			{
-#if !UNITY_EDITOR && UNITY_ANDROID && UNITY_ANDROID_JNI
+#if UNITY_ANDROID
+#if UNITY_ANDROID_JNI
+#if !UNITY_EDITOR
 				if( logcatListener == null )
 					logcatListener = new DebugLogLogcatListener();
 
 				logcatListener.Start( logcatArguments );
+#endif
+#else
+				Debug.LogWarning( "Android JNI module must be enabled in Package Manager for \"Receive Logcat Logs In Android\" to work." );
+#endif
 #endif
 			}
 

--- a/Plugins/IngameDebugConsole/Scripts/DebugLogManager.cs
+++ b/Plugins/IngameDebugConsole/Scripts/DebugLogManager.cs
@@ -439,7 +439,7 @@ namespace IngameDebugConsole
 		private bool isQuittingApplication;
 #endif
 
-#if !UNITY_EDITOR && UNITY_ANDROID
+#if !UNITY_EDITOR && UNITY_ANDROID && UNITY_ANDROID_JNI
 		private DebugLogLogcatListener logcatListener;
 #endif
 
@@ -601,7 +601,7 @@ namespace IngameDebugConsole
 
 			if( receiveLogcatLogsInAndroid )
 			{
-#if !UNITY_EDITOR && UNITY_ANDROID
+#if !UNITY_EDITOR && UNITY_ANDROID && UNITY_ANDROID_JNI
 				if( logcatListener == null )
 					logcatListener = new DebugLogLogcatListener();
 
@@ -634,7 +634,7 @@ namespace IngameDebugConsole
 			if( !receiveLogsWhileInactive )
 				Application.logMessageReceivedThreaded -= ReceivedLog;
 
-#if !UNITY_EDITOR && UNITY_ANDROID
+#if !UNITY_EDITOR && UNITY_ANDROID && UNITY_ANDROID_JNI
 			if( logcatListener != null )
 				logcatListener.Stop();
 #endif
@@ -717,7 +717,7 @@ namespace IngameDebugConsole
 			lastFrameCount = Time.frameCount;
 #endif
 
-#if !UNITY_EDITOR && UNITY_ANDROID
+#if !UNITY_EDITOR && UNITY_ANDROID && UNITY_ANDROID_JNI
 			if( logcatListener != null )
 			{
 				string log;


### PR DESCRIPTION
Define UNITY_ANDROID_JNI when the module `com.unity.modules.androidjni` is enabled so projects that have Android JNI disabled can avoid compilation errors.