### PR TITLE
fix: cannot write to console

### DIFF
--- a/Plugins/IngameDebugConsole/Scripts/EventSystemHandler.cs
+++ b/Plugins/IngameDebugConsole/Scripts/EventSystemHandler.cs
@@ -66,7 +66,7 @@ namespace IngameDebugConsole
 
 		private void DeactivateEventSystem()
 		{
-			if( embeddedEventSystem )
+           		if (embeddedEventSystem && EventSystem.current.gameObject != embeddedEventSystem)
 				embeddedEventSystem.SetActive( false );
 		}
 	}

--- a/Plugins/IngameDebugConsole/Scripts/EventSystemHandler.cs
+++ b/Plugins/IngameDebugConsole/Scripts/EventSystemHandler.cs
@@ -66,8 +66,11 @@ namespace IngameDebugConsole
 
 		private void DeactivateEventSystem()
 		{
-           		if (embeddedEventSystem && EventSystem.current.gameObject != embeddedEventSystem)
-				embeddedEventSystem.SetActive( false );
+           	        if (embeddedEventSystem)
+		        {
+		        	if (EventSystem.current && EventSystem.current.gameObject != embeddedEventSystem)
+		                    embeddedEventSystem.SetActive(false);
+		        }
 		}
 	}
 }


### PR DESCRIPTION
Embedded event system is deactivate in the case below:

1. I load a scene additive which does not have any EventSystem
2. This triggers OnSceneLoaded method in EventSystemHandler
3. I unload the old scene
4. This triggers OnSceneUnLoaded method in EventSystemHandler and thus triggers DeactivateEventSystem method. 
