### PR TITLE
Fixes for assembly reload in play mode breaking the ingameDebugConsole 

### DIFF
--- a/Plugins/IngameDebugConsole/Scripts/DebugLogManager.cs
+++ b/Plugins/IngameDebugConsole/Scripts/DebugLogManager.cs
@@ -586,14 +586,14 @@ namespace IngameDebugConsole
 		protected override void OnEnable()
 		{
 			base.OnEnable();
-			if ( Instance != this )
+			if( Instance != this )
 				return;
 
 			if( !receiveLogsWhileInactive )
-				{
-					Application.logMessageReceivedThreaded -= ReceivedLog;
-					Application.logMessageReceivedThreaded += ReceivedLog;
-				}
+			{
+				Application.logMessageReceivedThreaded -= ReceivedLog;
+				Application.logMessageReceivedThreaded += ReceivedLog;
+			}
 
 			if( receiveLogcatLogsInAndroid )
 			{

--- a/Plugins/IngameDebugConsole/Scripts/SingletonBehaviour.cs
+++ b/Plugins/IngameDebugConsole/Scripts/SingletonBehaviour.cs
@@ -7,18 +7,19 @@ namespace IngameDebugConsole
     [DisallowMultipleComponent]
     public abstract class SingletonBehaviour<T> : MonoBehaviour where T : SingletonBehaviour<T>
     {
-        [NonSerialized] bool _initialized;
+        [NonSerialized] bool initialized;
         public static T Instance { get; private set; }
         protected virtual void Awake()
         {
-            _initialized = false;
-            if ( Instance != null && Instance != this )
+            initialized = false;
+            if( Instance != null && Instance != this )
             {
-                Debug.LogWarning( $"Duplicate { typeof(T).Name } found. Destroying { gameObject.name }." );
+                Debug.LogWarning( $"Duplicate { typeof( T ).Name } found. Destroying { gameObject.name }." );
                 Destroy( gameObject );
 
                 return;
             }
+
             InitializeIfNeeded();
         }
 
@@ -29,11 +30,15 @@ namespace IngameDebugConsole
 
         private void InitializeIfNeeded()
         {
-            if ( !Application.isPlaying || _initialized )
+            if( !Application.isPlaying || initialized )
                 return;
+
             Instance = ( T )this;
-            _initialized = true;
-            if ( !ShouldDestroyOnLoad ) DontDestroyOnLoad( gameObject );
+            initialized = true;
+            
+            if( !ShouldDestroyOnLoad )
+                DontDestroyOnLoad( gameObject );
+
             Initialize();
         }
 
@@ -41,7 +46,8 @@ namespace IngameDebugConsole
 
         protected virtual void OnDestroy()
         {
-            if ( Instance == this ) Instance = null;
+            if( Instance == this )
+                Instance = null;
         }
 
         abstract protected bool ShouldDestroyOnLoad { get; }

--- a/Plugins/IngameDebugConsole/Scripts/SingletonBehaviour.cs
+++ b/Plugins/IngameDebugConsole/Scripts/SingletonBehaviour.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+using System;
+
+namespace IngameDebugConsole
+{
+    [DefaultExecutionOrder(-10000)]
+    [DisallowMultipleComponent]
+    public abstract class SingletonBehaviour<T> : MonoBehaviour where T : SingletonBehaviour<T>
+    {
+        [NonSerialized] bool _initialized;
+        public static T Instance { get; private set; }
+        protected virtual void Awake()
+        {
+            _initialized = false;
+            if ( Instance != null && Instance != this )
+            {
+                Debug.LogWarning( $"Duplicate { typeof(T).Name } found. Destroying { gameObject.name }." );
+                Destroy( gameObject );
+
+                return;
+            }
+            InitializeIfNeeded();
+        }
+
+        protected virtual void OnEnable()
+        {
+            InitializeIfNeeded();
+        }
+
+        private void InitializeIfNeeded()
+        {
+            if ( !Application.isPlaying || _initialized )
+                return;
+            Instance = ( T )this;
+            _initialized = true;
+            if ( !ShouldDestroyOnLoad ) DontDestroyOnLoad( gameObject );
+            Initialize();
+        }
+
+        protected virtual void Initialize() { }
+
+        protected virtual void OnDestroy()
+        {
+            if ( Instance == this ) Instance = null;
+        }
+
+        abstract protected bool ShouldDestroyOnLoad { get; }
+    }
+}

--- a/Plugins/IngameDebugConsole/Scripts/SingletonBehaviour.cs.meta
+++ b/Plugins/IngameDebugConsole/Scripts/SingletonBehaviour.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0f2137cb355492849ada390d14c3c320


### PR DESCRIPTION
Hi! I've been using this plugin for a while and I've been loving it, especially for the ability to create in-game commands to make testing easier!

This is mainly a fix for debugLogManager breaking after an assembly reload in play mode
Without this change, the assembly reload when changing a script in play mode tends to break UnityIngameDebugConsole, since awake is not called again to re-initialize DebugLogManager. This should also be [Domain Reload disabled on enter Play Mode](https://docs.unity3d.com/6000.2/Documentation/Manual/domain-reloading.html)-proof, since I run the console using that.